### PR TITLE
Remove debug fastlink for VS.

### DIFF
--- a/cmake/crashpad-common.cmake
+++ b/cmake/crashpad-common.cmake
@@ -38,11 +38,6 @@ else()
         /d2Zi+
         >
     )
-
-    target_link_options(crashpad_common INTERFACE
-        /INCREMENTAL:NO
-        /Debug:FASTLINK
-    )
 endif()
 
 if(WIN32)


### PR DESCRIPTION
Hello guys! Great job on the CMake integration of the Crashpad. 

Now to the point:
According to the CMake doc:
https://cmake.org/cmake/help/latest/command/target_link_options.html

> PUBLIC and INTERFACE items will populate the INTERFACE_LINK_OPTIONS property of <target>.

https://cmake.org/cmake/help/latest/prop_tgt/INTERFACE_LINK_OPTIONS.html#prop_tgt:INTERFACE_LINK_OPTIONS

> Targets may populate this property to publish the link options required to compile against the headers for the target.

Which means that  public/interface linking flags are contagious and are propagated to other targets. 
Which means if I want to build a library that is linked to the Crashpad with say DEBUG:FULL I cannot do that. Because it get's overwritten by this property I removed in the pull request. 

I suggest we remove it based on that.

Thanks for you time!
